### PR TITLE
Refactors main automation to RunAndSleep decision cycle

### DIFF
--- a/adhanapp.go
+++ b/adhanapp.go
@@ -33,14 +33,6 @@ const (
 	AUDIO_BIT_DEPTH = 2
 )
 
-const (
-	FIVE_SECONDS = 5 * time.Second
-
-	ONE_MINUTE   = 1 * time.Minute
-	TWO_MINUTES  = 2 * time.Minute
-	FIVE_MINUTES = 5 * time.Minute
-)
-
 func sleep(t time.Duration) {
 	log.Printf("Sleeping for %v", t)
 	time.Sleep(t)
@@ -67,51 +59,22 @@ func main() {
 		log.Fatalf("Failed to initialize NewAdhanPlayer: %v", err)
 	}
 
+	prayerTimes, err := NewMunichPrayerTimes()
+	if err != nil {
+		log.Fatalf("Failed to initialize NewPrayerTimes: %v", err)
+	}
+
+	automation, err := NewAutomation(adhanPlayer, homeassistant, prayerTimes)
+	if err != nil {
+		log.Fatalf("Failed to initialize NewAutomation: %v", err)
+	}
+
 	for {
-		// If Adhan is already playing, sleep for 5 minutes. We should loop again after
-		// sleep duration to turn off the speakers.
-		if adhanPlayer.IsPlaying() {
-			sleep(FIVE_MINUTES)
-			continue
-		}
-
-		now := time.Now()
-		prayertimes, err := GetTodayPrayerTimes()
+		sleepDuration, err := automation.RunAndSleep(time.Now())
 		if err != nil {
-			log.Fatalf("Failed to retrieve Prayer times today: %v", err)
+			log.Fatalf("Running the automation failed: %v", err)
 		}
-		prevPrayer, nextPrayer, err := prayertimes.GetNearestPrayers(now)
-		if err != nil {
-			log.Fatalf("Failed to get TimesToNearestPrayers: %v", err)
-		}
-		timeFromPrevPrayer := prevPrayer.TimeToPrayer(now)
-		timeToNextPrayer := nextPrayer.TimeToPrayer(now)
-		log.Printf("Time left till next prayer(%v): %v", nextPrayer, timeToNextPrayer)
 
-		switch {
-		// Play the Adhan (1) If time for prayer or (2) the last prayer was less than
-		// 2 minutes ago and Adhan did not play yet.
-		case timeFromPrevPrayer < TWO_MINUTES || timeToNextPrayer == 0:
-			if _, err := homeassistant.TurnSwitchOn(); err != nil {
-				log.Fatalf("error making a switch action: %v", err)
-			}
-
-			// give chance for the speaker to turn on before playing.
-			sleep(FIVE_SECONDS)
-
-			if err := adhanPlayer.Play(); err != nil {
-				log.Fatalf("error playing the Adhan: %v", err)
-			}
-
-		// Turn off speakers and Sleep till 5 minutes before next Prayer.
-		case timeToNextPrayer > FIVE_MINUTES:
-			if _, err := homeassistant.TurnSwitchOff(); err != nil {
-				log.Fatalf("error making a switch action: %v", err)
-			}
-			log.Printf("Next prayer: %v", timeToNextPrayer)
-			sleep(timeToNextPrayer - FIVE_MINUTES)
-		default:
-			sleep(ONE_MINUTE)
-		}
+		sleep(sleepDuration)
 	}
 }

--- a/automation.go
+++ b/automation.go
@@ -1,0 +1,97 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// automation contains all the logic for adhan playing, waiting and rewinding.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"time"
+)
+
+const (
+	FIVE_SECONDS = 5 * time.Second
+
+	ONE_MINUTE   = 1 * time.Minute
+	TWO_MINUTES  = 2 * time.Minute
+	FIVE_MINUTES = 5 * time.Minute
+)
+
+type automation struct {
+	adhanPlayer   IAdhanPlayer
+	homeassistant IHomeAssistant
+	prayerTimes   IPrayerTimes
+}
+
+func NewAutomation(ap *adhanPlayer, ha *homeassistant, pa *munichPrayerTimes) (*automation, error) {
+	if ap == nil {
+		return nil, errors.New("Automation expects a non-nil AdhanPlayer.")
+	}
+	if ha == nil {
+		return nil, errors.New("Automation expects a non-nil Homeassistant instance.")
+	}
+	if pa == nil {
+		return nil, errors.New("Automation expects a non-nil PrayerTimes instance.")
+	}
+	return &automation{ap, ha, pa}, nil
+}
+
+// returns sleep amount
+func (a *automation) RunAndSleep(now time.Time) (time.Duration, error) {
+	if a.adhanPlayer.IsPlaying() {
+		return FIVE_MINUTES, nil
+	}
+
+	if err := a.prayerTimes.GetTodayPrayerTimes(now); err != nil {
+		return 0, fmt.Errorf("Failed to repopulate Prayertimes: %w", err)
+	}
+
+	prevPrayer, nextPrayer, err := a.prayerTimes.GetNearestPrayers(now)
+	if err != nil {
+		return 0, fmt.Errorf("Failed to get TimesToNearestPrayers: %w", err)
+	}
+
+	timeFromPrevPrayer := prevPrayer.TimeToPrayer(now)
+	timeToNextPrayer := nextPrayer.TimeToPrayer(now)
+	log.Printf("Time left till %v: %v", nextPrayer, timeToNextPrayer)
+
+	switch {
+	// Play the Adhan (1) If time for prayer or (2) the last prayer was less than
+	// 2 minutes ago and Adhan did not play yet.
+	case timeFromPrevPrayer < TWO_MINUTES || timeToNextPrayer == 0:
+		if _, err := a.homeassistant.TurnSwitchOn(); err != nil {
+			return 0, fmt.Errorf("error making a switch action: %w", err)
+		}
+
+		// give chance for the speaker to turn on before playing.
+		sleep(FIVE_SECONDS)
+
+		if err := a.adhanPlayer.Play(); err != nil {
+			return 0, fmt.Errorf("error playing the Adhan: %w", err)
+		}
+
+	// Turn off speakers and Sleep till 5 minutes before next Prayer.
+	case timeToNextPrayer > FIVE_MINUTES:
+		if _, err := a.homeassistant.TurnSwitchOff(); err != nil {
+			return 0, fmt.Errorf("error making a switch action: %w", err)
+		}
+		log.Printf("Next prayer: %v", timeToNextPrayer)
+		return timeToNextPrayer - FIVE_MINUTES, nil
+	}
+
+	return ONE_MINUTE, nil
+}

--- a/automation.go
+++ b/automation.go
@@ -50,7 +50,9 @@ func NewAutomation(ap *adhanPlayer, ha *homeassistant, pa *munichPrayerTimes) (*
 	return &automation{ap, ha, pa}, nil
 }
 
-// returns sleep amount
+// RunAndSleep (1) takes decision based on the daily prayer times and current timestamp
+// (2) plays the adhan and (3) switch on/off the speakers and (4) returns sleep amount for
+// the next iteration.
 func (a *automation) RunAndSleep(now time.Time) (time.Duration, error) {
 	if a.adhanPlayer.IsPlaying() {
 		return FIVE_MINUTES, nil

--- a/automation_test.go
+++ b/automation_test.go
@@ -1,0 +1,195 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const (
+	playAction = 1 << iota
+	isPlayingAction
+
+	TurnSwitchOnAction
+	TurnSwitchOffAction
+)
+
+type adhanPlayerMock struct {
+	isPlaying    bool
+	actionLogger *[]int
+}
+
+func (a *adhanPlayerMock) Play() error {
+	*a.actionLogger = append(*a.actionLogger, playAction)
+	return nil
+}
+
+func (a *adhanPlayerMock) IsPlaying() bool {
+	if a.isPlaying {
+		*a.actionLogger = append(*a.actionLogger, isPlayingAction)
+		return true
+	}
+	return false
+}
+
+type homeassistantMock struct {
+	actionLogger *[]int
+}
+
+func (h *homeassistantMock) TurnSwitchOn() (string, error) {
+	*h.actionLogger = append(*h.actionLogger, TurnSwitchOnAction)
+	return "success", nil
+}
+
+func (h *homeassistantMock) TurnSwitchOff() (string, error) {
+	*h.actionLogger = append(*h.actionLogger, TurnSwitchOffAction)
+	return "success", nil
+}
+
+type prayerTimesMock struct {
+	prayerTimes
+}
+
+func (p *prayerTimesMock) GetTodayPrayerTimes(now time.Time) error {
+	parse := func(s string) time.Time {
+		c, _ := time.Parse("15:04", s)
+		return c
+	}
+
+	p.prayerTimes = prayerTimes{
+		Fajr:    &prayer{time: parse("09:00")},
+		Dhuhr:   &prayer{time: parse("12:00")},
+		Asr:     &prayer{time: parse("15:00")},
+		Maghrib: &prayer{time: parse("18:00")},
+		Ishaa:   &prayer{time: parse("21:00")},
+	}
+	return nil
+}
+
+func TestRunAndSleep(t *testing.T) {
+	parse := func(s string) time.Time {
+		c, err := time.Parse("15:04", s)
+		if err != nil {
+			t.Fatalf("Failed to parse the time %v: %v", s, err)
+		}
+		return c
+	}
+
+	for _, test := range []struct {
+		description string
+		isPlaying   bool
+		now         time.Time
+
+		wantSleepDuration  time.Duration
+		wantActionSequence []int
+	}{
+		{
+			description: "Adhan currently playing should send automation to sleep",
+			isPlaying:   true,
+
+			wantSleepDuration:  FIVE_MINUTES,
+			wantActionSequence: []int{isPlayingAction},
+		},
+		{
+			description: "Fajr time should turnSwitchOn and play",
+			now:         parse("09:00"),
+
+			wantSleepDuration:  ONE_MINUTE,
+			wantActionSequence: []int{TurnSwitchOnAction, playAction},
+		},
+		{
+			description: "1 minutes after Dhuhr should turnSwitchOn and play",
+			now:         parse("12:01"),
+
+			wantSleepDuration:  ONE_MINUTE,
+			wantActionSequence: []int{TurnSwitchOnAction, playAction},
+		},
+		{
+			description: "10 minutes after Dhuhr should turnSwitchOff and Sleep",
+			now:         parse("12:10"),
+
+			// Sleep from 12:10 to 5 minutes to 15:00 (Asr)
+			wantSleepDuration:  time.Minute*45 + time.Hour*2,
+			wantActionSequence: []int{TurnSwitchOffAction},
+		},
+		{
+			description: "5 minutes before Asr time should Sleep (default 1 minute)",
+			now:         parse("14:55"),
+
+			wantSleepDuration:  ONE_MINUTE,
+			wantActionSequence: []int{},
+		},
+		{
+			description: "7 minutes before Asr time should Sleep",
+			now:         parse("14:53"),
+
+			wantSleepDuration:  TWO_MINUTES,
+			wantActionSequence: []int{TurnSwitchOffAction},
+		},
+	} {
+		t.Run(test.description, func(t *testing.T) {
+			actions := []int{}
+			a := automation{
+				&adhanPlayerMock{isPlaying: test.isPlaying, actionLogger: &actions},
+				&homeassistantMock{actionLogger: &actions},
+				&prayerTimesMock{}}
+
+			sleepDuration, err := a.RunAndSleep(test.now)
+			if err != nil {
+				t.Errorf("RunAndSleep expects no error. Got %v", err)
+			}
+			if sleepDuration != test.wantSleepDuration {
+				t.Errorf("RunAndSleep sleep duration mismatch. Got %v, want %v", sleepDuration, test.wantSleepDuration)
+			}
+			if !cmp.Equal(actions, test.wantActionSequence) {
+				t.Errorf("RunAndSleep sleep action seqeuence mismatch. Got %v, want %v", actions, test.wantActionSequence)
+			}
+		})
+	}
+}
+
+func TestNewAutomation(t *testing.T) {
+	for _, test := range []struct {
+		description string
+		ha          *homeassistant
+		ap          *adhanPlayer
+		pt          *munichPrayerTimes
+	}{
+		{
+			description: "Homeassistant is missing",
+			ap:          &adhanPlayer{},
+			pt:          &munichPrayerTimes{},
+		},
+		{
+			description: "AdhanPlayer is missing",
+			ha:          &homeassistant{},
+			pt:          &munichPrayerTimes{},
+		},
+		{
+			description: "MunichPrayerTimes is missing",
+			ap:          &adhanPlayer{},
+			ha:          &homeassistant{},
+		},
+	} {
+		t.Run(test.description, func(t *testing.T) {
+			if _, err := NewAutomation(test.ap, test.ha, test.pt); err == nil {
+				t.Errorf("NewAutomation expected an error on init. Got none.")
+			}
+		})
+	}
+}

--- a/automation_test.go
+++ b/automation_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+// Actions enum. Used by mocks to test the validity of the action sequences.
 const (
 	playAction = 1 << iota
 	isPlayingAction
@@ -135,7 +136,7 @@ func TestRunAndSleep(t *testing.T) {
 			wantActionSequence: []int{},
 		},
 		{
-			description: "7 minutes before Asr time should Sleep",
+			description: "7 minutes before Asr time should sleep 2 minutes (till 5 min before Asr)",
 			now:         parse("14:53"),
 
 			wantSleepDuration:  TWO_MINUTES,

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,12 @@ module example.com/m/v2
 go 1.20
 
 require (
+	github.com/google/go-cmp v0.5.9
+	github.com/hajimehoshi/go-mp3 v0.3.4
+	github.com/hajimehoshi/oto/v2 v2.4.0
+)
+
+require (
 	github.com/ebitengine/purego v0.3.0 // indirect
-	github.com/hajimehoshi/go-mp3 v0.3.4 // indirect
-	github.com/hajimehoshi/oto/v2 v2.4.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/ebitengine/purego v0.3.0 h1:BDv9pD98k6AuGNQf3IF41dDppGBOe0F4AofvhFtBXF4=
 github.com/ebitengine/purego v0.3.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hajimehoshi/go-mp3 v0.3.4 h1:NUP7pBYH8OguP4diaTZ9wJbUbk3tC0KlfzsEpWmYj68=
 github.com/hajimehoshi/go-mp3 v0.3.4/go.mod h1:fRtZraRFcWb0pu7ok0LqyFhCUrPeMsGRSVop0eemFmo=
 github.com/hajimehoshi/oto/v2 v2.3.1/go.mod h1:seWLbgHH7AyUMYKfKYT9pg7PhUu9/SisyJvNTT+ASQo=

--- a/homeassistant.go
+++ b/homeassistant.go
@@ -32,6 +32,11 @@ const (
 	STATUS  SwitchAction = "/api/states/"
 )
 
+type IHomeAssistant interface {
+	TurnSwitchOn() (string, error)
+	TurnSwitchOff() (string, error)
+}
+
 type homeassistant struct {
 	client *httpclient
 

--- a/httpclient.go
+++ b/httpclient.go
@@ -25,13 +25,13 @@ import (
 	"strings"
 )
 
-// clientInterface is used for mocking Do().
-type clientInterface interface {
+// iClient is used for mocking Do() in unit tests.
+type iClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
 type httpclient struct {
-	client clientInterface
+	client iClient
 	token  string
 }
 

--- a/player.go
+++ b/player.go
@@ -28,6 +28,11 @@ import (
 	"github.com/hajimehoshi/oto/v2"
 )
 
+type IAdhanPlayer interface {
+	Play() error
+	IsPlaying() bool
+}
+
 type adhanPlayer struct {
 	player oto.Player
 
@@ -119,12 +124,4 @@ func (a *adhanPlayer) IsPlaying() bool {
 		return true
 	}
 	return false
-}
-
-func (a *adhanPlayer) Stop() error {
-	err := a.player.Close()
-	if err != nil {
-		return fmt.Errorf("AdhanPlayer closing failed: %w", err)
-	}
-	return nil
 }

--- a/prayertimes.go
+++ b/prayertimes.go
@@ -24,7 +24,7 @@ import (
 )
 
 // source: https://www.islamisches-zentrum-muenchen.de/
-var munichYearly = [][]string{
+var munich2023 = [][]string{
 	{"06:10", "07:59", "12:22", "14:15", "16:35", "18:17", "06:11", "07:59", "12:23", "14:15", "16:36", "18:18", "06:11", "07:59", "12:23", "14:16", "16:37", "18:19", "06:11", "07:59", "12:23", "14:17", "16:38", "18:20", "06:11", "07:59", "12:24", "14:18", "16:39", "18:21", "06:11", "07:59", "12:24", "14:19", "16:40", "18:22", "06:10", "07:58", "12:25", "14:20", "16:41", "18:23", "06:10", "07:58", "12:25", "14:21", "16:42", "18:24", "06:10", "07:58", "12:26", "14:22", "16:44", "18:25", "06:10", "07:57", "12:26", "14:23", "16:45", "18:26", "06:10", "07:57", "12:26", "14:24", "16:46", "18:27", "06:09", "07:56", "12:27", "14:26", "16:47", "18:28", "06:09", "07:56", "12:27", "14:27", "16:49", "18:29", "06:09", "07:55", "12:28", "14:28", "16:50", "18:30", "06:08", "07:54", "12:28", "14:29", "16:51", "18:32", "06:08", "07:54", "12:28", "14:30", "16:53", "18:33", "06:07", "07:53", "12:29", "14:31", "16:54", "18:34", "06:07", "07:52", "12:29", "14:33", "16:56", "18:35", "06:06", "07:51", "12:29", "14:34", "16:57", "18:36", "06:05", "07:51", "12:30", "14:35", "16:59", "18:38", "06:05", "07:50", "12:30", "14:36", "17:00", "18:39", "06:04", "07:49", "12:30", "14:38", "17:02", "18:40", "06:03", "07:48", "12:30", "14:39", "17:03", "18:41", "06:03", "07:47", "12:31", "14:40", "17:05", "18:43", "06:02", "07:46", "12:31", "14:41", "17:06", "18:44", "06:01", "07:45", "12:31", "14:43", "17:08", "18:45", "06:00", "07:44", "12:31", "14:44", "17:09", "18:47", "05:59", "07:42", "12:32", "14:45", "17:11", "18:48", "05:58", "07:41", "12:32", "14:47", "17:12", "18:49", "05:57", "07:40", "12:32", "14:48", "17:14", "18:51", "05:56", "07:39", "12:32", "14:49", "17:16", "18:52"},
 	{"05:55", "07:37", "12:32", "14:51", "17:17", "18:53", "05:54", "07:36", "12:32", "14:52", "17:19", "18:55", "05:53", "07:35", "12:32", "14:53", "17:20", "18:56", "05:52", "07:33", "12:33", "14:54", "17:22", "18:58", "05:50", "07:32", "12:33", "14:56", "17:24", "18:59", "05:49", "07:30", "12:33", "14:57", "17:25", "19:00", "05:48", "07:29", "12:33", "14:58", "17:27", "19:02", "05:47", "07:27", "12:33", "15:00", "17:28", "19:03", "05:45", "07:26", "12:33", "15:01", "17:30", "19:05", "05:44", "07:24", "12:33", "15:02", "17:32", "19:06", "05:42", "07:23", "12:33", "15:03", "17:33", "19:07", "05:41", "07:21", "12:33", "15:05", "17:35", "19:09", "05:40", "07:19", "12:33", "15:06", "17:36", "19:10", "05:38", "07:18", "12:33", "15:07", "17:38", "19:12", "05:37", "07:16", "12:33", "15:08", "17:40", "19:13", "05:35", "07:14", "12:33", "15:10", "17:41", "19:15", "05:33", "07:13", "12:33", "15:11", "17:43", "19:16", "05:32", "07:11", "12:33", "15:12", "17:44", "19:18", "05:30", "07:09", "12:33", "15:13", "17:46", "19:19", "05:28", "07:07", "12:32", "15:15", "17:48", "19:21", "05:27", "07:06", "12:32", "15:16", "17:49", "19:22", "05:25", "07:04", "12:32", "15:17", "17:51", "19:23", "05:23", "07:02", "12:32", "15:18", "17:52", "19:25", "05:22", "07:00", "12:32", "15:19", "17:54", "19:26", "05:20", "06:58", "12:32", "15:20", "17:55", "19:28", "05:18", "06:56", "12:32", "15:21", "17:57", "19:29", "05:16", "06:54", "12:32", "15:23", "17:59", "19:31", "05:14", "06:53", "12:31", "15:24", "18:00", "19:32"},
 	{"05:12", "06:51", "12:31", "15:25", "18:02", "19:34", "05:10", "06:49", "12:31", "15:26", "18:03", "19:36", "05:08", "06:47", "12:31", "15:27", "18:05", "19:37", "05:06", "06:45", "12:31", "15:28", "18:06", "19:39", "05:04", "06:43", "12:30", "15:29", "18:08", "19:40", "05:02", "06:41", "12:30", "15:30", "18:09", "19:42", "05:00", "06:39", "12:30", "15:31", "18:11", "19:43", "04:58", "06:37", "12:30", "15:32", "18:12", "19:45", "04:56", "06:35", "12:29", "15:33", "18:14", "19:46", "04:54", "06:33", "12:29", "15:34", "18:15", "19:48", "04:52", "06:31", "12:29", "15:35", "18:17", "19:49", "04:50", "06:29", "12:29", "15:36", "18:18", "19:51", "04:48", "06:27", "12:28", "15:37", "18:20", "19:53", "04:46", "06:25", "12:28", "15:38", "18:21", "19:54", "04:43", "06:23", "12:28", "15:39", "18:23", "19:56", "04:41", "06:21", "12:28", "15:40", "18:24", "19:57", "04:39", "06:19", "12:27", "15:41", "18:26", "19:59", "04:37", "06:17", "12:27", "15:42", "18:27", "20:01", "04:35", "06:15", "12:27", "15:42", "18:29", "20:02", "04:32", "06:12", "12:26", "15:43", "18:30", "20:04", "04:30", "06:10", "12:26", "15:44", "18:32", "20:06", "04:28", "06:08", "12:26", "15:45", "18:33", "20:07", "04:25", "06:06", "12:25", "15:46", "18:35", "20:09", "04:23", "06:04", "12:25", "15:47", "18:36", "20:11", "04:21", "06:02", "12:25", "15:48", "18:38", "20:12", "05:18", "07:00", "13:25", "16:48", "19:39", "21:18", "05:16", "06:58", "13:24", "16:49", "19:40", "21:16", "05:14", "06:56", "13:24", "16:50", "19:42", "21:18", "05:11", "06:54", "13:24", "16:51", "19:43", "21:19", "05:09", "06:52", "13:23", "16:51", "19:45", "21:21", "05:06", "06:50", "13:23", "16:52", "19:46", "21:23"},
@@ -44,6 +44,7 @@ type prayer struct {
 	time time.Time
 }
 
+// returns duration from now till an input prayer.
 func (p *prayer) TimeToPrayer(now time.Time) time.Duration {
 	if now.Compare(p.time) > 0 {
 		// prayer has passed
@@ -53,49 +54,25 @@ func (p *prayer) TimeToPrayer(now time.Time) time.Duration {
 	return p.time.Sub(now)
 }
 
+// IPrayerTimes is an interface to be used by specific cities or a global
+// prayer time calculator.
+type IPrayerTimes interface {
+	GetTodayPrayerTimes(now time.Time) error
+	GetNearestPrayers(now time.Time) (*prayer, *prayer, error)
+}
+
+// prayerTimes contains all 5 prayers and the date (yyyy-mm-dd) for caching.
 type prayerTimes struct {
 	Fajr    *prayer
 	Dhuhr   *prayer
 	Asr     *prayer
 	Maghrib *prayer
 	Ishaa   *prayer
+
+	date time.Time
 }
 
-func GetTodayPrayerTimes() (*prayerTimes, error) {
-	d := time.Now()
-
-	pts := []time.Time{}
-	for i := 0; i < 6; i++ {
-		parsed, err := time.Parse("15:04", munichYearly[d.Month()-1][6*(d.Day()-1)+i])
-		if err != nil {
-			return nil, err
-		}
-
-		tt := time.Date(d.Year(), d.Month(), d.Day(), parsed.Hour(), parsed.Minute(), 0, 0, d.Location())
-
-		if i == 1 {
-			// We don't consider Ishraq.
-			continue
-		}
-		pts = append(pts, tt)
-	}
-
-	pt := &prayerTimes{
-		Fajr:    &prayer{name: "Fajr", time: pts[0]},
-		Dhuhr:   &prayer{name: "Dhuhr", time: pts[1]},
-		Asr:     &prayer{name: "Asr", time: pts[2]},
-		Maghrib: &prayer{name: "Maghrib", time: pts[3]},
-		Ishaa:   &prayer{name: "Ishaa", time: pts[4]},
-	}
-
-	if !isSameDay(d, pt.Fajr.time, pt.Dhuhr.time, pt.Asr.time, pt.Maghrib.time, pt.Ishaa.time) {
-		return nil, fmt.Errorf("Failed to find time to closest prayer. Found Inconsistency of dates between now (%v) and today's prayers(%v)", d, pt)
-	}
-
-	log.Printf("PrayerTimes today: %v", pt)
-	return pt, nil
-}
-
+// GetNearestPrayers returns the previous and next *prayers given a timestamp.
 func (p *prayerTimes) GetNearestPrayers(now time.Time) (*prayer, *prayer, error) {
 	switch {
 	case now.Equal(p.Fajr.time) || now.Before(p.Fajr.time):
@@ -123,6 +100,57 @@ func (p *prayerTimes) GetNearestPrayers(now time.Time) (*prayer, *prayer, error)
 	}
 }
 
+// munichPrayerTimes extends prayerTimes to reuse GetNearestPrayers.
+type munichPrayerTimes struct {
+	prayerTimes
+}
+
+func NewMunichPrayerTimes() (*munichPrayerTimes, error) {
+	pt := &munichPrayerTimes{}
+	if err := pt.GetTodayPrayerTimes(time.Now()); err != nil {
+		return nil, fmt.Errorf("Error initializing NewPrayerTimes for %s: %w", time.Now().Format("2006-01-02"), err)
+	}
+	return pt, nil
+}
+
+// GetTodayPrayerTimes is specific to Munich as it reads from static prayer times.
+func (p *munichPrayerTimes) GetTodayPrayerTimes(now time.Time) error {
+	if !p.date.IsZero() && p.date == GetDate(now) {
+		return nil
+	}
+
+	pts := []time.Time{}
+	for i := 0; i < 6; i++ {
+		t := munich2023[now.Month()-1][6*(now.Day()-1)+i]
+		parsed, err := time.Parse("15:04", t)
+		if err != nil {
+			return fmt.Errorf("Error parsing prayertime %v: %w", t, err)
+		}
+
+		tt := time.Date(now.Year(), now.Month(), now.Day(), parsed.Hour(), parsed.Minute(), 0, 0, now.Location())
+
+		if i == 1 {
+			// We don't consider Ishraq.
+			continue
+		}
+		pts = append(pts, tt)
+	}
+
+	p.Fajr = &prayer{name: "Fajr", time: pts[0]}
+	p.Dhuhr = &prayer{name: "Dhuhr", time: pts[1]}
+	p.Asr = &prayer{name: "Asr", time: pts[2]}
+	p.Maghrib = &prayer{name: "Maghrib", time: pts[3]}
+	p.Ishaa = &prayer{name: "Ishaa", time: pts[4]}
+	p.date = GetDate(now)
+
+	if !isSameDay(now, p.Fajr.time, p.Dhuhr.time, p.Asr.time, p.Maghrib.time, p.Ishaa.time) {
+		return fmt.Errorf("Failed to find time to closest prayer. Found Inconsistency of dates between now (%v) and today's prayers(%v)", now, p)
+	}
+
+	log.Printf("PrayerTimes today: %v", p)
+	return nil
+}
+
 // isSameDay returns True if all input timestamps have the same date.
 func isSameDay(tss ...time.Time) bool {
 	if len(tss) < 2 {
@@ -139,11 +167,12 @@ func isSameDay(tss ...time.Time) bool {
 	return true
 }
 
-func midNight(ts time.Time) time.Time {
-	return time.Date(ts.Year(), ts.Month(), ts.Day(), 0, 0, 0, 0, ts.Location())
-}
-
 // isBetweenPrayers returns True if input timestamp is within prayerA and prayerB
 func isBetweenPrayers(prayerA, ts time.Time, prayerB time.Time) bool {
 	return ts.After(prayerA) && ts.Before(prayerB) || ts.Equal(prayerB)
+}
+
+// GetDate returns Date (yyyy-mm-dd) of a given timestamp.
+func GetDate(n time.Time) time.Time {
+	return time.Date(n.Year(), n.Month(), n.Day(), 0, 0, 0, 0, n.Location())
 }


### PR DESCRIPTION
Instead of cramming the logic in the main file. This PR refactors it instead to the following:

```go
// Automation is initialized with all action classes.
automation, err := NewAutomation(adhanPlayer, homeassistant, prayerTimes)
if err != nil { ... }

for {
  // RunAndSleep takes decision and actuates, returns sleep duration for the next decision making cycle.
  sleepDuration, err := automation.RunAndSleep(time.Now())
  if err != nil { ... }

  sleep(sleepDuration)
}
```